### PR TITLE
feat: notify via WhatsApp when webhook processed

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -19,6 +19,12 @@ export const config = {
     timeout: parseInt(process.env.WEBHOOK_TIMEOUT) || 5000,
     secret: process.env.WEBHOOK_SECRET
   },
+  waha: {
+    url: process.env.WAHA_URL || 'http://localhost:3000/api/sendText',
+    apiKey: process.env.WAHA_API_KEY,
+    session: process.env.WAHA_SESSION || 'default',
+    chatId: process.env.WAHA_CHAT_ID
+  },
   logging: {
     level: process.env.LOG_LEVEL || 'warn',
     file: process.env.LOG_FILE || 'logs/trade-monitor.log'

--- a/src/services/wahaService.js
+++ b/src/services/wahaService.js
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { config } from '../config/config.js';
+import logger from '../utils/logger.js';
+
+class WahaService {
+  constructor() {
+    this.url = config.waha.url;
+    this.apiKey = config.waha.apiKey;
+    this.session = config.waha.session;
+    this.chatId = config.waha.chatId;
+
+    if (!this.url || !this.chatId) {
+      logger.warn('⚠️  WAHA no configurado. No se enviarán notificaciones a WhatsApp.');
+    }
+  }
+
+  async enviarMensaje(texto) {
+    if (!this.url || !this.chatId) {
+      return false;
+    }
+
+    const data = {
+      session: this.session,
+      chatId: this.chatId,
+      text: texto
+    };
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (this.apiKey) {
+      headers['X-Api-Key'] = this.apiKey;
+    }
+
+    try {
+      const response = await axios.post(this.url, data, { headers });
+      logger.info(`📲 Notificación WhatsApp enviada (${response.status})`);
+      return true;
+    } catch (error) {
+      logger.error('❌ Error enviando notificación WhatsApp:', { message: error.message });
+      return false;
+    }
+  }
+}
+
+export default new WahaService();

--- a/src/services/webhookService.js
+++ b/src/services/webhookService.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import crypto from 'crypto';
 import { config } from '../config/config.js';
 import logger from '../utils/logger.js';
+import wahaService from './wahaService.js';
 
 class WebhookService {
   constructor() {
@@ -27,6 +28,7 @@ class WebhookService {
   async enviarWebhook(trade, tipo = 'TRADE_OPEN') {
     if (!this.webhookUrl) {
       logger.warn('Webhook no enviado: URL no configurada');
+      await wahaService.enviarMensaje('Webhook no enviado: URL no configurada');
       return false;
     }
 
@@ -83,7 +85,8 @@ class WebhookService {
       });
 
       logger.info(`✅ Webhook enviado exitosamente para trade ${trade.id}: ${response.status}`);
-      
+      await wahaService.enviarMensaje(`Webhook enviado para trade ${trade.id} (${tipo})`);
+
       return {
         success: true,
         status: response.status,
@@ -96,6 +99,7 @@ class WebhookService {
         status: error.response?.status,
         data: error.response?.data
       });
+      await wahaService.enviarMensaje(`Error enviando webhook para trade ${trade.id}: ${error.message}`);
 
       return {
         success: false,


### PR DESCRIPTION
## Summary
- add WAHA configuration options
- send WhatsApp notifications for webhook events and failures

## Testing
- `npm test` *(fails: Token de API inválido o respuesta inesperada)*

------
https://chatgpt.com/codex/tasks/task_e_68952e4757b08323a052661939b65af1